### PR TITLE
Hook up weather and minor combat start/end change

### DIFF
--- a/DalamudPlugin/RaidsRewritten/EncounterManager.cs
+++ b/DalamudPlugin/RaidsRewritten/EncounterManager.cs
@@ -43,7 +43,7 @@ public sealed class EncounterManager : IDalamudHook
     ];
     private readonly Dictionary<ushort, IEncounter> encounters;
 
-    private bool InCombat = false;
+    private bool? InCombat = null;
     private byte Weather = 0;
 
     public EncounterManager(
@@ -355,9 +355,15 @@ public sealed class EncounterManager : IDalamudHook
             }
         }
 
+        if (!this.InCombat.HasValue)
+        {
+            this.InCombat = combatState;
+            return;
+        }
+
         if (combatState)
         {
-            if (!this.InCombat)
+            if (!this.InCombat.Value)
             {
                 this.InCombat = true;
                 this.logger.Debug("COMBAT STARTED");
@@ -373,7 +379,7 @@ public sealed class EncounterManager : IDalamudHook
             }
         } else
         {
-            if (this.InCombat)
+            if (this.InCombat.Value)
             {
                 this.InCombat = false;
                 this.logger.Debug("COMBAT ENDED");

--- a/DalamudPlugin/RaidsRewritten/Scripts/Mechanic.cs
+++ b/DalamudPlugin/RaidsRewritten/Scripts/Mechanic.cs
@@ -48,6 +48,8 @@ public abstract class Mechanic()
 
     public virtual void OnCombatEnd() { }
 
+    public virtual void OnWeatherChange(byte weather) { }
+
     public class Factory(DalamudServices dalamud, EcsContainer ecsContainer, AttackManager attackManager, ILogger logger)
     {
         public T Create<T>() where T : Mechanic, new()


### PR DESCRIPTION
Minor combat start/end change makes the initial state a null field so OnCombatStart/OnCombatEnd doesn't run when I reload the plugin